### PR TITLE
Make Zinc builds both reproducible and RBE-compatible

### DIFF
--- a/rules/private/phases/phase_zinc_compile.bzl
+++ b/rules/private/phases/phase_zinc_compile.bzl
@@ -76,7 +76,7 @@ def phase_zinc_compile(ctx, g):
             g.classpaths.plugin,
             g.classpaths.compile,
             g.classpaths.compiler,
-        ],
+        ] + [zinc.deps_files for zinc in zincs],
     )
 
     outputs = [g.classpaths.jar, mains_file, apis, infos, relations, setup, stamps, used, tmp]


### PR DESCRIPTION
Before, we removed some inputs to ScalaCompile actions that made builds reproducible, but not RBE-compatible. This branch revives some work and adds to it to sort Zinc information, making builds both reproducible and RBE-compatible. 