### PR TITLE
Exit Worker process on Fatal exceptions

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -249,6 +249,14 @@ object ZincRunner extends WorkerMain[Namespace] {
           System.err.println(e)
           println("You may be missing a `macro = True` attribute.")
           sys.exit(1)
+        case e: StackOverflowError => {
+          // Downgrade to NonFatal error.
+          // The JVM is not guaranteed to free shared resources correctly when unwinding the stack to catch a StackOverflowError,
+          // but since we don't share resources between work threads, this should be mostly safe for us for now.
+          // If Bazel could better handle the worker shutting down suddenly, we could allow this to be caught by
+          // the UncaughtExceptionHandler in WorkerMain, and exit the entire process to be safe.
+          throw new Error("StackOverflowError", e)
+        }
       }
 
     // create analyses


### PR DESCRIPTION
The default global ExecutionContext simply logs uncaught exceptions. Since Future only catches NonFatal exceptions, any Fatal exceptions would cause the Future to never complete, which meant a WorkResponse was never sent back to the bazel server, which would then be stuck waiting forever for a response.

Since Fatal exceptions can leave the JVM in an invalid state, we exit if any thread has an unhandled Fatal exception.