### PR TITLE
Don't include AnalyisCache files as action inputs

### DIFF
--- a/rules/private/phases/phase_zinc_compile.bzl
+++ b/rules/private/phases/phase_zinc_compile.bzl
@@ -76,7 +76,7 @@ def phase_zinc_compile(ctx, g):
             g.classpaths.plugin,
             g.classpaths.compile,
             g.classpaths.compiler,
-        ] + [zinc.deps_files for zinc in zincs],
+        ],
     )
 
     outputs = [g.classpaths.jar, mains_file, apis, infos, relations, setup, stamps, used, tmp]


### PR DESCRIPTION
We're seeing cache determinism issues again since re-adding these.

NOTE: this change makes the ScalaCompile action incompatible with RE.
We'll need to re-evaluate how to make these files deterministic before exploring RE on this rule set again.