### PR TITLE
Handle specs2 scopes by themselves properly

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
@@ -29,10 +29,21 @@ object TestHelper {
     f: Runner => A
   ) = {
     val options =
-      if (framework.name == "specs2") {
-        // Get rid of any extra context before the test name (specs2 doesn't recognize it)
-        val testName = scopeAndTestName.replaceAll(raw"(?<=\\Q).*::", "")
-        Array("-ex", testName)
+      if (framework.name == "specs2" && scopeAndTestName.contains("::")) {
+        // scopeAndTestName from intellij has the format '\Q${scope}::${test}\E$' for individual tests,
+        // and '\Q${scope}\E::' for scopes (see getTestFilter in com.google.idea.blaze.scala.run.Specs2Utils).
+        // specs2 filters only on test, not on scope. If we get just a scope, pass nothing.
+        // If we get a test name, give it to specs2.
+        // (wrapping a portion of a regex in a \Q and a \E escapes everything in between them)
+        val Array(scope, testName): Array[String] = scopeAndTestName.split("::", 2)
+        if (testName.nonEmpty) {
+          // \Q is the only thing from scope that we _don't_ want to drop (since it's not actually part of the scope,
+          // it's part of the overall regex)
+          val prefix = if (scope.startsWith(raw"\Q")) raw"\Q" else ""
+          Array("-ex", prefix + testName)
+        } else {
+          Array.empty[String]
+        }
       } else Array.empty[String]
     val runner = framework.runner(arguments.toArray, options, classLoader)
     try f(runner)

--- a/tests/test-frameworks/specs2/test
+++ b/tests/test-frameworks/specs2/test
@@ -2,3 +2,4 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel test :specs2 "--test_filter=annex.specs2.Specs2TestFilter#\Qscala_test should::properly (escape) [special] characters in the test filter\E$" | grep "1 example"
+bazel test :specs2 "--test_filter=annex.specs2.Specs2TestFilter#\Qscala_test should\E::" | grep "1 example"


### PR DESCRIPTION
b9436b0 Assumed that when the test filter is just a scope, the ::
separating the scope and the (absent) test name would be escaped along
with the scope, as it is when there is a test name. However, this is not
the case. Just the scope is escaped, and the :: is not. So, replacing
everything after the starting \Q, up to and including the ::, with
nothing gets rid of the \E (which, when there's just a scope, is before
the ::) which is needed for the \Q to work properly.