### PR TITLE
Handle labels in Bazel 6

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 common       --config=rules
 common:v5.0 --config=rules_v5.0
+common:v6.3 --config=rules_v6.3
 import %workspace%/.bazelrc_shared

--- a/.bazelrc_shared
+++ b/.bazelrc_shared
@@ -26,18 +26,15 @@ test --test_output=all
 #build:rules --disk_cache=.bazel_cache
 #build:tests --disk_cache=../.bazel_cache
 
-# bazel 4.2.1
-common:rules_v4.1 --config=noop
-common:rules_v4.2 --config=noop
 common:rules_v5.0 --config=noop
+common:rules_v6.3 --config=noop
 
 # route potentially unrouted configs to a terminating noop config
 # it's a noop because we use the default value
 common:rules --config=noop
 common:tests --config=noop
-common:v4.1 --config=rules_v4.1
-common:v4.2 --config=rules_v4.2
 common:v5.0 --config=rules_v5.0
+common:v6.3 --config=rules_v6.3
 
 # pick something trivial as a "noop"
 common:noop --logging=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
-        bazel_version: [4.1.0, 4.2.1, 5.0.0]
+        os: [ubuntu-20.04]
+        bazel_version: [5.0.0, 6.3.2]
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci.sh build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -178,3 +178,20 @@ scala_proto_register_toolchains()
 load("@annex_proto//:defs.bzl", annex_proto_pinned_maven_install = "pinned_maven_install")
 
 annex_proto_pinned_maven_install()
+
+# rules_pkg
+
+rules_pkg_version = "0.7.0"
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
+        "https://github.com/bazelbuild/rules_pkg/releases/download/{v}/rules_pkg-{v}.tar.gz".format(v = rules_pkg_version),
+    ],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 
 [

--- a/tests/dependencies/indirect/test
+++ b/tests/dependencies/indirect/test
@@ -3,7 +3,7 @@
 
 # used_deps off
 ! bazel build :used_deps_off_c || false
-bazel build :used_deps_off_c |& grep "buildozer 'add deps //dependencies/indirect:used_deps_off_a' //dependencies/indirect:used_deps_off_c"
+bazel build :used_deps_off_c |& grep "buildozer 'add deps @\?//dependencies/indirect:used_deps_off_a' //dependencies/indirect:used_deps_off_c"
 
 # direct_deps off
 ! bazel build :direct_deps_off_c || false
@@ -11,7 +11,7 @@ bazel build :direct_deps_off_c |& grep "buildozer 'remove deps //dependencies/in
 
 # toggle used_deps and direct_deps via --define
 ! bazel build --define=scala_deps_used=off :define_c || false
-bazel build --define=scala_deps_used=off :define_c |& grep "buildozer 'add deps //dependencies/indirect:define_a' //dependencies/indirect:define_c"
+bazel build --define=scala_deps_used=off :define_c |& grep "buildozer 'add deps @\?//dependencies/indirect:define_a' //dependencies/indirect:define_c"
 
 ! bazel build --define=scala_deps_direct=off :define_c || false
 bazel build --define=scala_deps_direct=off :define_c |& grep "buildozer 'remove deps //dependencies/indirect:define_a' //dependencies/indirect:define_b"

--- a/tools/bazel
+++ b/tools/bazel
@@ -15,7 +15,7 @@ abs_path() {
 workspace=$(cd $(dirname "$0")/..; pwd)
 root_workspace=$(cd $(dirname $(abs_path "$0"))/..; pwd)
 
-default_bazel_version='5.0.0'
+default_bazel_version='6.3.2'
 
 if [ -z "$BAZEL_VERSION" ]; then
     bazel_version="$default_bazel_version"
@@ -23,22 +23,17 @@ else
     bazel_version="$BAZEL_VERSION"
 fi
 
+# SHA comes from `bazel-<version>-installer-<platform>-x86_64.sh.sha256` on https://github.com/bazelbuild/bazel/releases
 case "$bazel_version" in
     'host')
         bazel_version=$("$BAZEL_REAL" version | awk '/Build label/ {print $3}' | cut -d '-' -f 1)
         bazel="$BAZEL_REAL"
         ;;
-    '4.1.0')
-        darwin_sha='fddad9367ed8e2687e8b52f5d8de29798de4cc2860d1c70e91128dcbc515d8ca'
-        linux_sha='e3f08054165be0a5e90779654b0e5c68d262ae794407d6347cdc6e8d05fafaaf'
-        ;;
-    '4.2.1')
-        darwin_sha='967189ebadd6b65b1dd25464fdd4d2fcff7a00e0b776be425b19e283432d7862'
-        linux_sha='35f398ad93af2b5eadd4b6b4fd4d4803b726029e572f40c4e1fe736db3de944b'
-        ;;
     '5.0.0')
-        darwin_sha='f7e8d1eac85ec125c430f9553e35d522c057895262956201ccea8a27d87054cc'
         linux_sha='42cfb37d2834d075996b9d02698674be7f322f0acd864b17c3191301329845f9'
+        ;;
+    '6.3.2')
+        linux_sha='f117506267ed148d5f4f9844bcf187c4f111dad7ff4f1a9eb1f4e45331f3f9f0'
         ;;
     *)
         echo "The requested Bazel version '$bazel_version' is not supported"
@@ -54,10 +49,6 @@ fi
 
 if ! [ -f "$bazel" ]; then
     case $(uname -s) in
-        Darwin)
-            platform='darwin'
-            sha=$darwin_sha
-            ;;
         Linux)
             platform='linux'
             sha=$linux_sha


### PR DESCRIPTION
When compiling a project that's using Bazel 6, the Deps Check would fail with `java.util.NoSuchElementException: key not found: //path/to/target` because the label is now `@//path/to/target` in the `labelToPaths` map