### PR TITLE
Enable -s arg for selenium test running

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -49,6 +49,9 @@ object TestRunner {
       .addArgument("--framework_args")
       .help("Additional arguments for testing framework")
     parser
+      .addArgument("-s")
+      .help("Test class selector flag")
+    parser
   }
 
   private[this] val testArgParser = {
@@ -142,7 +145,10 @@ object TestRunner {
     val frameworks = testNamespace.getList[String]("frameworks").asScala.flatMap(loader.load)
 
     val testFilter = sys.env.get("TESTBRIDGE_TEST_ONLY").map(_.split("#", 2))
-    val testClass = testFilter.map(_.head).map(Pattern.compile)
+    val testClass = testFilter
+      .map(_.head)
+      .orElse(Option(namespace.getString("s")))
+      .map(Pattern.compile)
     val testScopeAndName = testFilter.flatMap(_.lift(1))
 
     var count = 0

--- a/tests/test-frameworks/testrunner/BUILD
+++ b/tests/test-frameworks/testrunner/BUILD
@@ -1,0 +1,21 @@
+load("@rules_scala_annex//rules:scala.bzl", "scala_library", "scala_test")
+
+scala_test(
+    name = "testrunnertest",
+    srcs = glob(["*.scala"]),
+    deps = [
+        "@annex_test//:org_specs2_specs2_common_2_13",
+        "@annex_test//:org_specs2_specs2_core_2_13",
+        "@annex_test//:org_specs2_specs2_matcher_2_13",
+    ],
+)
+
+scala_library(
+    name = "aatestrunner",
+    srcs = glob(["*.scala"]),
+    deps = [
+        "@annex_test//:org_specs2_specs2_common_2_13",
+        "@annex_test//:org_specs2_specs2_core_2_13",
+        "@annex_test//:org_specs2_specs2_matcher_2_13",
+    ],
+)

--- a/tests/test-frameworks/testrunner/BadTestThatIsFilteredOut.scala
+++ b/tests/test-frameworks/testrunner/BadTestThatIsFilteredOut.scala
@@ -1,0 +1,13 @@
+package annex.specs2
+
+import org.specs2.mutable.Specification
+
+object BadTestThatIsFilteredOut extends Specification {
+
+  "this" should {
+    "will not pass" in {
+      true must_== false
+    }
+  }
+
+}

--- a/tests/test-frameworks/testrunner/TestRunnerSpec.scala
+++ b/tests/test-frameworks/testrunner/TestRunnerSpec.scala
@@ -1,0 +1,13 @@
+package annex.specs2
+
+import org.specs2.mutable.Specification
+
+object TestRunnerSpec extends Specification {
+
+  "args" should {
+    "be parsed" in {
+      true must_== true
+    }
+  }
+
+}

--- a/tests/test-frameworks/testrunner/test
+++ b/tests/test-frameworks/testrunner/test
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. "$(dirname "$0")"/../../common.sh
+
+# `bazel test :testrunnertest`` will fail because BadTestThatIsFilteredOut fails
+# This test makes sure that we can filter a target to just a specific test
+
+bazel test --test_arg=-s --test_arg=TestRunnerSpec -- :testrunnertest
+
+


### PR DESCRIPTION
Tested many E2E tests
Tested a few controller unit tests

Passes locally
`./scripts/test.sh`