### PR TITLE
Fix non-worker output and also bootstrap scalac nondeterminism

### DIFF
--- a/rules/private/phases/phase_bootstrap_compile.bzl
+++ b/rules/private/phases/phase_bootstrap_compile.bzl
@@ -21,6 +21,8 @@ def phase_bootstrap_compile(ctx, g):
         transitive = [ctx.attr._jdk[java_common.JavaRuntimeInfo].files, g.classpaths.compile, g.classpaths.compiler],
     )
 
+    tmp = ctx.actions.declare_directory("{}/tmp/classes".format(ctx.label.name))
+
     compiler_classpath = ":".join([f.path for f in g.classpaths.compiler.to_list()])
     compile_classpath = ":".join([f.path for f in g.classpaths.compile.to_list()])
     srcs = " ".join([f.path for f in g.classpaths.srcs])
@@ -31,37 +33,39 @@ def phase_bootstrap_compile(ctx, g):
     if int(scala_configuration.version[0]) >= 3:
         main_class = "dotty.tools.dotc.Main"
 
-    ctx.actions.run_shell(
-        inputs = inputs,
-        tools = [ctx.executable._jar_creator],
-        outputs = [g.classpaths.jar],
-        command = _strip_margin(
-            """
+    command = _strip_margin(
+        """
             |set -eo pipefail
-            |
-            |mkdir -p tmp/classes
             |
             |{java} \\
             |  -cp {compiler_classpath} \\
             |  {main_class} \\
             |  -cp {compile_classpath} \\
-            |  -d tmp/classes \\
+            |  -d {tmp} \\
             |  {global_scalacopts} \\
             |  {scalacopts} \\
             |  {srcs}
             |
-            |{jar_creator} {output_jar} tmp/classes 2> /dev/null
+            |{jar_creator} {output_jar} {tmp} 2> /dev/null
             |""".format(
-                compiler_classpath = compiler_classpath,
-                compile_classpath = compile_classpath,
-                global_scalacopts = " ".join(scala_configuration.global_scalacopts),
-                java = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path,
-                jar_creator = ctx.executable._jar_creator.path,
-                main_class = main_class,
-                output_jar = g.classpaths.jar.path,
-                scalacopts = " ".join(ctx.attr.scalacopts),
-                srcs = srcs,
-            ),
+            compiler_classpath = compiler_classpath,
+            compile_classpath = compile_classpath,
+            global_scalacopts = " ".join(scala_configuration.global_scalacopts),
+            java = ctx.attr._jdk[java_common.JavaRuntimeInfo].java_executable_exec_path,
+            jar_creator = ctx.executable._jar_creator.path,
+            main_class = main_class,
+            output_jar = g.classpaths.jar.path,
+            scalacopts = " ".join(ctx.attr.scalacopts),
+            srcs = srcs,
+            tmp = tmp.path,
         ),
+    )
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        tools = [ctx.executable._jar_creator],
+        mnemonic = "BootstrapScalacompile",
+        outputs = [g.classpaths.jar, tmp],
+        command = command,
         execution_requirements = _resolve_execution_reqs(ctx, {}),
     )

--- a/tests/compile/error/test
+++ b/tests/compile/error/test
@@ -1,4 +1,5 @@
 #!/bin/bash -e
 . "$(dirname "$0")"/../../common.sh
 
-bazel build :lib 2>&1 | grep -q $'\[\e\[31mError\e\[0m\] compile/error/Example\.scala:'
+bazel build --strategy=ScalaCompile=worker :lib 2>&1 | grep -q $'\[\e\[31mError\e\[0m\] compile/error/Example\.scala:'
+bazel build --strategy=ScalaCompile=local :lib 2>&1 | grep -q $'\[\e\[31mError\e\[0m\] compile/error/Example\.scala:'


### PR DESCRIPTION
Fixes anything that inherits from WorkerMain not writing to the console when not run as a worker.

Fixes a non-determinism bug with bootstrap scalac actions. Check that commit message for a more detailed explanation.