### PR TITLE
Support -sources.jar source jars and sourcejars with MANIFEST.MF files in them

### DIFF
--- a/rules/private/phases/phase_classpaths.bzl
+++ b/rules/private/phases/phase_classpaths.bzl
@@ -58,7 +58,12 @@ def phase_classpaths(ctx, g):
     ).transitive_runtime_jars
 
     srcs = [file for file in ctx.files.srcs if file.extension.lower() in ["java", "scala"]]
-    src_jars = [file for file in ctx.files.srcs if file.extension.lower() in ["srcjar"]]
+    src_jars = [
+        file
+        for file in ctx.files.srcs
+        if file.path.lower().endswith(".srcjar") or file.path.lower().endswith("-sources.jar") or
+           file.path.lower().endswith("-src.jar")
+    ]
 
     jar = ctx.actions.declare_file("{}/classes.jar".format(ctx.label.name))
 

--- a/rules/private/phases/phase_javainfo.bzl
+++ b/rules/private/phases/phase_javainfo.bzl
@@ -28,15 +28,6 @@ def phase_javainfo(ctx, g):
     if len(ctx.attr.srcs) == 0 and len(ctx.attr.resources) == 0:
         java_info = java_common.merge([g.classpaths.sdeps, sexports, sruntime_deps])
     else:
-        # TODO: why do ijars break Scala 3?
-        # For some yet unknown reason ijars break Scala 3.
-        # Bazel now handles .tasty files, but the Scala 3 test fails to pass
-        # when this ijar is used as the compile jar. My guess is that the
-        # classfile format changed somehow for Scala 3 and Bazel does not yet
-        # handle that.
-        #
-        # In the meantime, we've added a use_ijar Scala configuration value and
-        # only use ijars for Scala 2 targets.
         compile_jar = ctx.outputs.jar
         if (ctx.attr.scala[_ScalaConfiguration].use_ijar):
             compile_jar = java_common.run_ijar(

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -501,7 +501,7 @@ configure_bootstrap_scala = rule(
             doc = "Scalac options that will always be enabled.",
         ),
         "use_ijar": attr.bool(
-            doc = "Whether to use ijars for this compiler. Scala 3 currently cannot use ijars.",
+            doc = "Whether to use ijars for this compiler.",
             default = True,
         ),
     },
@@ -535,7 +535,7 @@ _configure_zinc_scala = rule(
             default = "warn",
         ),
         "use_ijar": attr.bool(
-            doc = "Whether to use ijars for this compiler. Scala 3 currently cannot use ijars.",
+            doc = "Whether to use ijars for this compiler.",
             default = True,
         ),
         "deps_direct": attr.string(default = "error"),

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -84,11 +84,13 @@ _compile_private_attributes = {
 
 _compile_attributes = {
     "srcs": attr.label_list(
-        doc = "The source Scala and Java files (and `.srcjar` files of those).",
+        doc = "The source Scala and Java files (and `-sources.jar` `.srcjar` `-src.jar` files of those).",
         allow_files = [
             ".scala",
             ".java",
             ".srcjar",
+            "-sources.jar",
+            "-src.jar",
         ],
         flags = ["DIRECT_COMPILE_TIME_INPUT"],
     ),
@@ -455,6 +457,8 @@ scaladoc = rule(
                 ".java",
                 ".scala",
                 ".srcjar",
+                "-sources.jar",
+                "-src.jar",
             ]),
             "scala": attr.label(
                 default = "@scala",

--- a/rules/scala/private/doc.bzl
+++ b/rules/scala/private/doc.bzl
@@ -36,7 +36,12 @@ def scaladoc_implementation(ctx):
     )
 
     srcs = [file for file in ctx.files.srcs if file.extension.lower() in ["java", "scala"]]
-    src_jars = [file for file in ctx.files.srcs if file.extension.lower() == "srcjar"]
+    src_jars = [
+        file
+        for file in ctx.files.srcs
+        if file.path.lower().endswith(".srcjar") or file.path.lower().endswith("-sources.jar") or
+           file.path.lower().endswith("-src.jar")
+    ]
 
     scalacopts = ["-doc-title", ctx.attr.title or ctx.label] + ctx.attr.scalacopts
 

--- a/rules/scala/private/import.bzl
+++ b/rules/scala/private/import.bzl
@@ -24,7 +24,11 @@ def scala_import_implementation(ctx):
         _jar = []
         _src_jar = []
         for jar in ctx.files.jars:
-            if jar.basename.endswith("sources.jar") or jar.basename.endswith("src.jar"):
+            if (
+                jar.basename.lower().endswith("-sources.jar") or
+                jar.basename.lower().endswith("-src.jar") or
+                jar.basename.lower().endswith(".srcjar")
+            ):
                 _src_jar.append(jar)
             else:
                 _jar.append(jar)

--- a/src/main/scala/BUILD
+++ b/src/main/scala/BUILD
@@ -96,7 +96,7 @@ configure_bootstrap_scala(
     compiler_classpath = compiler_classpath_3,
     global_scalacopts = shared_global_scalacopts,
     runtime_classpath = runtime_classpath_3,
-    use_ijar = False,
+    use_ijar = True,
     version = scala_3_version,
     visibility = ["//visibility:public"],
 )
@@ -107,7 +107,7 @@ configure_zinc_scala(
     compiler_classpath = compiler_classpath_3,
     global_scalacopts = shared_global_scalacopts,
     runtime_classpath = runtime_classpath_3,
-    use_ijar = False,
+    use_ijar = True,
     version = scala_3_version,
     visibility = ["//visibility:public"],
 )

--- a/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/common/FileUtil.scala
@@ -102,7 +102,7 @@ object FileUtil {
       else extractZip(archive, output)
     }
 
-  def extractZip(archive: Path, output: Path) = {
+  def extractZip(archive: Path, output: Path): List[Path] = {
     val fileStream = Files.newInputStream(archive)
     try {
       val zipStream = new ZipInputStream(fileStream)

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -107,6 +107,8 @@ object ZincRunner extends WorkerMain[Namespace] {
               FileUtil.extractZip(jar.toPath, sourcesDir.resolve(i.toString))
             }
           }
+          // Filter out MANIFEST files as they are not source files
+          .filterNot(_.endsWith("META-INF/MANIFEST.MF"))
           .map(_.toFile)
     }
 

--- a/tests/compile/srcjar/.gitignore
+++ b/tests/compile/srcjar/.gitignore
@@ -1,1 +1,3 @@
 example.srcjar
+example-sources.jar
+example-src.jar

--- a/tests/compile/srcjar/BUILD
+++ b/tests/compile/srcjar/BUILD
@@ -1,7 +1,19 @@
 load("@rules_scala_annex//rules:scala.bzl", "scala_library")
 
 scala_library(
-    name = "lib",
+    name = "lib-srcjar",
     srcs = ["example.srcjar"],
+    scala = "//scala:2_13",
+)
+
+scala_library(
+    name = "lib-sources-jar",
+    srcs = ["example-sources.jar"],
+    scala = "//scala:2_13",
+)
+
+scala_library(
+    name = "lib-src-jar",
+    srcs = ["example-src.jar"],
     scala = "//scala:2_13",
 )

--- a/tests/compile/srcjar/META-INF/MANIFEST.MF
+++ b/tests/compile/srcjar/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Created-By: rules_scala_annex

--- a/tests/compile/srcjar/test
+++ b/tests/compile/srcjar/test
@@ -1,8 +1,20 @@
 #!/bin/bash -e
 . "$(dirname "$0")"/../../common.sh
 
-zip example.srcjar Example.scala
-bazel build :lib
+zip -FSr example.srcjar Example.scala META-INF/MANIFEST.MF
+bazel build :lib-srcjar
 diff <( sort expected)  <(
-   zipinfo -m -T --h-t "$(bazel info bazel-bin)/compile/srcjar/lib.jar" | sort
+   zipinfo -m -T --h-t "$(bazel info bazel-bin)/compile/srcjar/lib-srcjar.jar" | sort
+)
+
+zip -FSr example-sources.jar Example.scala META-INF/MANIFEST.MF
+bazel build :lib-sources-jar
+diff <( sort expected)  <(
+   zipinfo -m -T --h-t "$(bazel info bazel-bin)/compile/srcjar/lib-sources-jar.jar" | sort
+)
+
+zip -FSr example-src.jar Example.scala META-INF/MANIFEST.MF
+bazel build :lib-src-jar
+diff <( sort expected)  <(
+   zipinfo -m -T --h-t "$(bazel info bazel-bin)/compile/srcjar/lib-src-jar.jar" | sort
 )

--- a/tests/plugins/macros/test
+++ b/tests/plugins/macros/test
@@ -1,9 +1,6 @@
 #!/bin/bash -e
 . "$(dirname "$0")"/../../common.sh
 
-# TODO: Re-enable this test once Scala 3 works with ijars
-# macro = True makes you use full jars, and we're doing that
-# all the time now because Scala 3 +ijar breaks. So this always passes
-#bazel build :bad_compile 2>&1 | grep 'You may be missing a `macro = True` attribute.'
+bazel build :bad_compile 2>&1 | grep 'You may be missing a `macro = True` attribute.'
 [ "$(bazel run :test_macro)" = "hello world!" ]
 [ "$(bazel run :test_macro_only)" = $'hello world!\nworld hello!' ]

--- a/tests/scala/BUILD
+++ b/tests/scala/BUILD
@@ -110,7 +110,7 @@ configure_bootstrap_scala(
     name = "bootstrap_3",
     compiler_classpath = compiler_classpath_3,
     runtime_classpath = runtime_classpath_3,
-    use_ijar = False,
+    use_ijar = True,
     version = scala_3_version,
     visibility = ["//visibility:public"],
 )
@@ -120,7 +120,7 @@ configure_zinc_scala(
     compiler_bridge = "@annex//:org_scala_lang_scala3_sbt_bridge",
     compiler_classpath = compiler_classpath_3,
     runtime_classpath = runtime_classpath_3,
-    use_ijar = False,
+    use_ijar = True,
     version = scala_3_version,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
We only handled .srcjar before, but many source jars are -sources.jar

Also many source jars have MANIFEST.MF files in them. We were treating those as Scala sources before this fix, which is not correct.