### PR TITLE
make rules scala compatible with bazelbsp

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -9,3 +9,6 @@ targets:
 
 additional_languages:
   scala
+
+enabled_rules:
+    rules_scala_annex

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ target/
 /.vscode/
 /bazel.iml
 *.iml
+/.bazelbsp/
+/.bsp/
+/.metals/

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -15,53 +15,61 @@ load(
 )
 
 def configure_bootstrap_scala_implementation(ctx):
-    return [
-        _ScalaConfiguration(
-            compiler_classpath = ctx.attr.compiler_classpath,
-            global_plugins = ctx.attr.global_plugins,
-            global_scalacopts = ctx.attr.global_scalacopts,
-            runtime_classpath = ctx.attr.runtime_classpath,
-            semanticdb_bundle = ctx.attr.semanticdb_bundle,
-            use_ijar = ctx.attr.use_ijar,
-            version = ctx.attr.version,
-        ),
-        _ScalaRulePhase(
-            phases = [
-                ("=", "compile", "compile", _phase_bootstrap_compile),
-            ],
-        ),
-    ]
+    scala_configuration = _ScalaConfiguration(
+        compiler_classpath = ctx.attr.compiler_classpath,
+        global_plugins = ctx.attr.global_plugins,
+        global_scalacopts = ctx.attr.global_scalacopts,
+        runtime_classpath = ctx.attr.runtime_classpath,
+        semanticdb_bundle = ctx.attr.semanticdb_bundle,
+        use_ijar = ctx.attr.use_ijar,
+        version = ctx.attr.version,
+    )
+    return struct(
+        scala_configuration = scala_configuration,
+        providers = [
+            scala_configuration,
+            _ScalaRulePhase(
+                phases = [
+                    ("=", "compile", "compile", _phase_bootstrap_compile),
+                ],
+            ),
+        ],
+    )
 
 def configure_zinc_scala_implementation(ctx):
-    return [
-        _ScalaConfiguration(
-            compiler_classpath = ctx.attr.compiler_classpath,
-            global_plugins = ctx.attr.global_plugins,
-            global_scalacopts = ctx.attr.global_scalacopts,
-            runtime_classpath = ctx.attr.runtime_classpath,
-            semanticdb_bundle = ctx.attr.semanticdb_bundle,
-            use_ijar = ctx.attr.use_ijar,
-            version = ctx.attr.version,
-        ),
-        _CodeCoverageConfiguration(
-            instrumentation_worker = ctx.attr._code_coverage_instrumentation_worker,
-        ),
-        _ZincConfiguration(
-            compile_worker = ctx.attr._compile_worker,
-            compiler_bridge = ctx.file.compiler_bridge,
-            log_level = ctx.attr.log_level,
-            incremental = ctx.attr.incremental,
-        ),
-        _DepsConfiguration(
-            direct = ctx.attr.deps_direct,
-            used = ctx.attr.deps_used,
-            worker = ctx.attr._deps_worker,
-        ),
-        _ScalaRulePhase(
-            phases = [
-                ("=", "compile", "compile", _phase_zinc_compile),
-                ("-", "compile", "semanticdb", _phase_semanticdb),
-                ("+", "compile", "depscheck", _phase_zinc_depscheck),
-            ],
-        ),
-    ]
+    scala_configuration = _ScalaConfiguration(
+        compiler_classpath = ctx.attr.compiler_classpath,
+        global_plugins = ctx.attr.global_plugins,
+        global_scalacopts = ctx.attr.global_scalacopts,
+        runtime_classpath = ctx.attr.runtime_classpath,
+        semanticdb_bundle = ctx.attr.semanticdb_bundle,
+        use_ijar = ctx.attr.use_ijar,
+        version = ctx.attr.version,
+    )
+    return struct(
+        scala_configuration = scala_configuration,
+        providers = [
+            scala_configuration,
+            _CodeCoverageConfiguration(
+                instrumentation_worker = ctx.attr._code_coverage_instrumentation_worker,
+            ),
+            _ZincConfiguration(
+                compile_worker = ctx.attr._compile_worker,
+                compiler_bridge = ctx.file.compiler_bridge,
+                log_level = ctx.attr.log_level,
+                incremental = ctx.attr.incremental,
+            ),
+            _DepsConfiguration(
+                direct = ctx.attr.deps_direct,
+                used = ctx.attr.deps_used,
+                worker = ctx.attr._deps_worker,
+            ),
+            _ScalaRulePhase(
+                phases = [
+                    ("=", "compile", "compile", _phase_zinc_compile),
+                    ("-", "compile", "semanticdb", _phase_semanticdb),
+                    ("+", "compile", "depscheck", _phase_zinc_depscheck),
+                ],
+            ),
+        ],
+    )


### PR DESCRIPTION
@jadenPete actually wrote all of this, it just adds compiler information to the bazel providers(? or something, I don't know bazel that well) so bazelbsp can use it.