### PR TITLE
Compute the SemanticDB target root correctly

### DIFF
--- a/rules/private/phases/phase_semanticdb.bzl
+++ b/rules/private/phases/phase_semanticdb.bzl
@@ -15,7 +15,7 @@ def _semanticdb_directory_from_file(file):
     nested function closure by default.
     """
 
-    return "{}/{}".format(file.root.path, file.short_path[:file.short_path.find("META-INF") - 1])
+    return file.path[:file.path.find("META-INF") - 1]
 
 #
 # PHASE: semanticdb


### PR DESCRIPTION
In Bazel, `File#short_path` is prefixed with `..` if the file belongs to an external repository. However, this isn't meant to be interpreted as a relative path, as external repositories' outputs are in the `external` output directory.

This meant that when `semanticdb_bundle` was enabled and external repositories contained Scala rules, they'd fail to build, since the `-P:semanticdb:sourceroot` or `-semanticdb-target` compiler options would be computed incorrectly.