### PR TITLE
log unrecognized stamp types, but just go ahead and use them

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/common/AnnexMapper.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/common/AnnexMapper.scala
@@ -41,7 +41,7 @@ object AnnexMapper {
       case farmHash: FarmHash         => farmHash
       case hash: Hash                 => hash
       case lastModified: LastModified => new LastModified(JarHelper.DEFAULT_TIMESTAMP)
-      case _                          => throw new Exception("Unexpected Stamp type encountered when writing.")
+      case _ => throw new Exception(s"Unexpected Stamp type encountered when writing. ${stamp.getClass} -- $stamp")
     }
   }
 
@@ -66,7 +66,7 @@ object AnnexMapper {
       case lastModified: LastModified => {
         Stamper.forLastModifiedP(PlainVirtualFileConverter.converter.toPath(file))
       }
-      case _ => throw new Exception("Unexpected Stamp type encountered when reading")
+      case _ => throw new Exception(s"Unexpected Stamp type encountered when reading ${stamp.getClass} -- $stamp")
     }
   }
 }


### PR DESCRIPTION
This is a shot in the dark, but maybe we are not writing outputs sometimes because of unknown stamp types? Here is an example log where I see this getting thrown. I've changed the exception to a log (with stack trace) and then just continued using the stamp as is. [logs](https://lucid-jenkins-artifact-bucket.s3.amazonaws.com/build-jenkins/main/sheyne-doc-service-fixes/bazel-unified-build/18/artifacts/jenkins/multiplex-worker-18-ScalaCompile.log?X-Amz-Security-Token=IQoJb3JpZ2luX2VjEOf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQCkkComE4%2By3tJBqbUAsmLZpfR8AChNqqVh3klJ21na6wIgAUlzMV9nGnmmDH1uHzA2x2CkD95VSqm1rMnx%2FyYQ1csquwUIv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARADGgwyNTI3ODcwMzU3MTYiDDbJk3I7vF37I%2BpNJSqPBQ3oi0vrLM6MQOHgc3jTNJIv5xOFy4BL4TZl%2BjcJQN7CJ7a5HrGhaqnVAIQg2kt7I0rTBCgvZdy%2FbEN4X9vMZADiexHGWcfdS8zWftu0KrqtlPTGmDCrI6VcnPcpuSNgFhJHnw3LvxnQCYV0NQZAvrIGsRplgcX1vBuZ%2FpvKFpyHQME0kszheywTCLAKwmVTmkZvwf88d7LEYRVzCgSW3qHm%2BTZK3qEUK2OOOl3D5X8gQzMFf%2F6TCEUpms57hxC7NlGr%2FH5C4P%2FqFRD7Oqyhml3BcZznxM5u%2FLV77Epllb9I33tg%2BgbHL4c%2BV6G4Mfpwpx%2Fr7nqyKgYBEJ%2FJ8EDQ14SlmIXLrrbiq8joTS0RG%2BNBaOU55t1mruMWGgNgtGT7HGUAYuU6XTfNVvMSD2S9FQGzPXCWGoV8YISazHFf%2FE5QVwTleO6dkzhjmszdrm%2Batv2H%2FPB82zXNtVNytBLLJtREDKKjptxQ5D8JRJjCDEtX%2FcDnyW3k3MCDfHQyoP53geB5NaZP2X7lB50HBJk3ux%2BugB2NA0Em5r1Ly7KuO6RSiY2pxOt%2BAqPRm24vqo7ISMlhrWNJtYVsB%2FCIlSNqsqFMb4mXI2vgTGIT5ynxMuoyGnXwLjwaOB%2FP1O8iBARSzGLTh6M6O82sSRSnycwvj291zYqievfc8rLTUkKyLaOMboopPX29HEkYxQ%2F2QVbOil%2BeP%2BAYYCOLLtArnxdsP98MlR%2B3Melm8rHpBwPh8gJSuXv%2FAPHpGi9IbznJuxSzPSbfmJtgUo3j6ZZu2YEcwsRfhj6PeVX4cwLiTmfVmO29pGALaVsls3vxz%2Fz%2BGy7oHAvE38BT6J75z4Bg4P1np3Elt031CSUhXP18U6wsVtIw0PugwgY6sQExHBIHC4ikKbNZdYwWQq0yIfWiunxJYYLm7B0FWkcdtS55dZMlombBeuuUQCWFHKzcjW%2F6n%2BvQOrBOk5uxfZHbBb4A7KXjD7c23ur99O7CJsIJvv2HKw8CqAhzPyC%2BtFHIbQcJl7jJAf9U6X8qC2kgylGjp0F4lnfYQaRgzPH6q%2F%2FnggYJwR%2BaIA6bv13pck1V3dmoG0KGjFsTvPnmTCDPe7myz6%2FgTDU%2Fi71L2jaJWJ0%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250610T163917Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=ASIATVW2IBZCGR25IOH4%2F20250610%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=36dbd3be8d490aacecb3af4ec995d86a3bb0d6a9896206f1ff1641882a3318f1)