### PR TITLE
Don't provide -sourceroot twice

### DIFF
--- a/rules/private/phases/phase_semanticdb.bzl
+++ b/rules/private/phases/phase_semanticdb.bzl
@@ -66,7 +66,8 @@ def phase_semanticdb(ctx, g):
                 map_each = _semanticdb_directory_from_output_jar,
             )
 
-            arguments.add("--compiler_option_referencing_path=-sourceroot:${workDir}")
+            # We don't need to change `-sourceroot` in the Scala 3 case because `ZincRunner` already takes care of
+            # setting it to the work directory (so the generated TASTy files are deterministic)
             arguments.add("--compiler_option=-Ysemanticdb")
 
     g.out.providers.append(

--- a/tests/plugins/semanticdb/BUILD
+++ b/tests/plugins/semanticdb/BUILD
@@ -14,6 +14,7 @@ register_zinc_toolchain(
         "@annex_test//:org_scala_lang_scala_library",
     ],
     global_plugins = ["@annex_test//:org_scalameta_semanticdb_scalac_2_13_14"],
+    global_scalacopts = ["-Wconf:any:error"],
     runtime_classpath = ["@annex_test//:org_scala_lang_scala_library"],
     semanticdb_bundle = False,
     version = scala_2_13_version,
@@ -26,6 +27,7 @@ register_zinc_toolchain(
         "@annex_test//:org_scala_lang_scala3_compiler_3",
         "@annex_test//:org_scala_lang_scala3_library_3",
     ],
+    global_scalacopts = ["-Wconf:any:error"],
     runtime_classpath = [
         "@annex_test//:org_scala_lang_scala3_library_3",
         "@annex_test//:org_scala_lang_scala3_interfaces",


### PR DESCRIPTION
Currently, `-sourceroot` is provided twice to the compiler when the "semanticdb" ruleset phase is enabled. This commit fixes that.