### PR TITLE
Fix "Absent Code attribute in method" errors

### DIFF
--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -18,7 +18,7 @@ import net.sourceforge.argparse4j.ArgumentParsers
 import play.api.libs.json.Json
 import sbt.internal.inc.classfile.analyzeJavaClasses
 import sbt.internal.inc.classpath.ClassLoaderCache
-import sbt.internal.inc.javac.DiagnosticsReporter
+import sbt.internal.inc.javac.{DiagnosticsReporter, DirectoryClassFinder}
 import sbt.internal.inc.{CompileOutput, PlainVirtualFile, PlainVirtualFileConverter, ZincUtil}
 import sbt.internal.util.LoggerWriter
 import scala.jdk.CollectionConverters.*
@@ -160,9 +160,20 @@ object ZincRunner extends WorkerMain[Unit] {
     reporter: Reporter,
     logger: Logger,
   ): Unit = {
+    def findClassesInOutputDirectory(): Set[Path] = {
+      val classes = DirectoryClassFinder(classesOutputDirectory).classes
+
+      try {
+        classes.paths.toSet
+      } finally {
+        classes.close()
+      }
+    }
+
     val javaSources = normalizedSources.view.map(_.toString).filter(_.endsWith(".java")).toList
 
     if (javaSources.nonEmpty) {
+      val classesBeforeJavaCompilation = findClassesInOutputDirectory()
       val javaCompiler = ToolProvider.getSystemJavaCompiler
       val writer = new LoggerWriter(logger)
       val diagnosticListener = new DiagnosticsReporter(reporter)
@@ -201,7 +212,11 @@ object ZincRunner extends WorkerMain[Unit] {
 
       InterruptUtil.throwIfInterrupted(task.isCancelled)
 
+      val classesAfterJavaCompilation = findClassesInOutputDirectory()
+
       analyzeJavaClasses(
+        // Only provide the classes produced by the Java compiler, as those are the only ones we want to analyze
+        (classesAfterJavaCompilation -- classesBeforeJavaCompilation).toSeq,
         normalizedSources.view.map(PlainVirtualFile(_)).toList,
         parsedArguments.classpath,
         classesOutputDirectory,

--- a/src/main/scala/sbt/internal/inc/classfile/package.scala
+++ b/src/main/scala/sbt/internal/inc/classfile/package.scala
@@ -3,7 +3,6 @@ package sbt.internal.inc.classfile
 import java.io.File
 import java.nio.file.Path
 import sbt.internal.inc.classpath.ClasspathUtil
-import sbt.internal.inc.javac.DirectoryClassFinder
 import sbt.util.Logger
 import xsbti.compile.SingleOutput
 import xsbti.{AnalysisCallback, VirtualFile, VirtualFileRef}
@@ -20,40 +19,34 @@ import xsbti.{AnalysisCallback, VirtualFile, VirtualFileRef}
  * [[sbt.internal.inc.javac.AnalyzingJavaCompiler]].
  */
 def analyzeJavaClasses(
+  javaClasses: Seq[Path],
   sources: Seq[VirtualFile],
   classpath: Seq[Path],
   outputDirectory: Path,
   logger: Logger,
   analysisCallback: AnalysisCallback,
 ): Unit = {
-  val classFinder = new DirectoryClassFinder(outputDirectory)
-  val classes = classFinder.classes
-
-  try {
-    val output = new SingleOutput {
-      override def getOutputDirectory: File = outputDirectory.toFile
-    }
-
-    val classloader = ClasspathUtil.toLoader(outputDirectory +: classpath)
-
-    /**
-     * TODO: Make this more similar to the `readAPI` defined in [[sbt.internal.inc.javac.AnalyzingJavaCompiler]].
-     *
-     * This method is supposed to use [[sbt.internal.inc.ClassToAPI]] to analyze the list of provided classes and is
-     * supposed to return a set of inheritance pairs (`subclass -> superclass`, but it currently does nothing because I
-     * can't get it to work with `ijar`. [[sbt.internal.inc.ClassToAPI]] attempts to load the methods of the classes
-     * provided to it, which results in an error like this:
-     *
-     * {{{
-     *   java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file ...
-     * }}}
-     *
-     * I'm not sure how this worked when we used Zinc instead of the compiler bridge directly.
-     */
-    def readAPI(source: VirtualFileRef, classes: Seq[Class[?]]): Set[(String, String)] = Set.empty
-
-    JavaAnalyze(classes.paths, sources, logger, output, finalJarOutput = None)(analysisCallback, classloader, readAPI)
-  } finally {
-    classes.close()
+  val output = new SingleOutput {
+    override def getOutputDirectory: File = outputDirectory.toFile
   }
+
+  val classloader = ClasspathUtil.toLoader(outputDirectory +: classpath)
+
+  /**
+   * TODO: Make this more similar to the `readAPI` defined in [[sbt.internal.inc.javac.AnalyzingJavaCompiler]].
+   *
+   * This method is supposed to use [[sbt.internal.inc.ClassToAPI]] to analyze the list of provided classes and is
+   * supposed to return a set of inheritance pairs (`subclass -> superclass`, but it currently does nothing because I
+   * can't get it to work with `ijar`. [[sbt.internal.inc.ClassToAPI]] attempts to load the methods of the classes
+   * provided to it, which results in an error like this:
+   *
+   * {{{
+   *   java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file ...
+   * }}}
+   *
+   * I'm not sure how this worked when we used Zinc instead of the compiler bridge directly.
+   */
+  def readAPI(source: VirtualFileRef, classes: Seq[Class[?]]): Set[(String, String)] = Set.empty
+
+  JavaAnalyze(javaClasses, sources, logger, output, finalJarOutput = None)(analysisCallback, classloader, readAPI)
 }


### PR DESCRIPTION
Previously, during mixed compilation (compiling Scala and Java sources in the same target), instead of analyzing the compiled Java classes, we analyzed all classes in the output directory. Because we compile the Scala sources first, this meant Scala classes were being re-analyzed.

I'm not sure why some Scala classes were missing code attributes, but the errors should be fixed (and compilation should be faster) by not re-analyzing them to begin with.