### PR TITLE
Don't output temporary directories

### DIFF
--- a/rules/private/phases/phase_bootstrap_compile.bzl
+++ b/rules/private/phases/phase_bootstrap_compile.bzl
@@ -25,8 +25,6 @@ def phase_bootstrap_compile(ctx, g):
         ],
     )
 
-    tmp = ctx.actions.declare_directory("{}/tmp/classes".format(ctx.label.name))
-
     scala_configuration = g.javainfo.scala_info.scala_configuration
 
     main_class = "scala.tools.nsc.Main"
@@ -49,8 +47,6 @@ def phase_bootstrap_compile(ctx, g):
 
     if compile_classpath:
         args.add_joined("--compile_classpath", compile_classpath, join_with = ":")
-
-    args.add_all("--tmp", [tmp], expand_directories = False)
 
     if scala_configuration.global_scalacopts:
         args.add_joined("--global_scalacopts", scala_configuration.global_scalacopts, join_with = " ")
@@ -78,9 +74,6 @@ def phase_bootstrap_compile(ctx, g):
             |    --compile_classpath)
             |      compile_classpath="${2}"
             |      ;;
-            |    --tmp)
-            |      tmp="${2}"
-            |      ;;
             |    --global_scalacopts)
             |      global_scalacopts="${2}"
             |      ;;
@@ -104,16 +97,20 @@ def phase_bootstrap_compile(ctx, g):
             |  shift
             |done
             |
+            |class_directory="$(mktemp -d)"
+            |
+            |trap 'rm -rf -- "${class_directory}"' EXIT
+            |
             |"${java}" \\
             |  -cp "${compiler_classpath}" \\
             |  "${main_class}" \\
             |  -cp "${compile_classpath}" \\
-            |  -d "${tmp}" \\
+            |  -d "${class_directory}" \\
             |  ${global_scalacopts} \\
             |  ${scalacopts} \\
             |  ${srcs}
             |
-            |"${jar_creator}" "${output_jar}" "${tmp}" 2> /dev/null
+            |"${jar_creator}" "${output_jar}" "${class_directory}" 2> /dev/null
             |""",
     )
 
@@ -126,7 +123,7 @@ def phase_bootstrap_compile(ctx, g):
         inputs = inputs,
         mnemonic = "BootstrapScalaCompile",
         progress_message = "Bootstrap Compiling Scala %{label}",
-        outputs = [g.classpaths.jar, tmp],
+        outputs = [g.classpaths.jar],
         toolchain = "@rules_scala_annex//rules/scala:toolchain_type",
         tools = [ctx.executable._jar_creator],
     )

--- a/rules/private/phases/phase_zinc_compile.bzl
+++ b/rules/private/phases/phase_zinc_compile.bzl
@@ -16,7 +16,6 @@ def phase_zinc_compile(ctx, g):
     toolchain = ctx.toolchains["//rules/scala:toolchain_type"]
     mains_file = ctx.actions.declare_file("{}.jar.mains.txt".format(ctx.label.name))
     used = ctx.actions.declare_file("{}/deps_used.txt".format(ctx.label.name))
-    tmp = ctx.actions.declare_directory("{}/tmp".format(ctx.label.name))
 
     javacopts = [
         ctx.expand_location(option, ctx.attr.data)
@@ -43,7 +42,6 @@ def phase_zinc_compile(ctx, g):
     args.add("--output_used", used)
     args.add_all("--plugins", g.classpaths.plugin)
     args.add_all("--source_jars", g.classpaths.src_jars)
-    args.add_all("--tmp", [tmp], expand_directories = False)
     args.add("--log_level", toolchain.zinc_configuration.log_level)
 
     g.semanticdb.arguments_modifier(args)
@@ -57,7 +55,7 @@ def phase_zinc_compile(ctx, g):
         ],
     )
 
-    outputs = [g.classpaths.jar, mains_file, used, tmp] + g.semanticdb.outputs
+    outputs = [g.classpaths.jar, mains_file, used] + g.semanticdb.outputs
 
     if hasattr(ctx.attr, "frameworks"):
         tests_file = ctx.actions.declare_file("{}/tests.json".format(ctx.label.name))

--- a/rules/scala/private/doc.bzl
+++ b/rules/scala/private/doc.bzl
@@ -26,7 +26,6 @@ def scaladoc_implementation(ctx):
     )
 
     html = ctx.actions.declare_directory("html")
-    tmp = ctx.actions.declare_directory("tmp")
 
     classpath = depset(transitive = [dep[JavaInfo].transitive_compile_time_jars for dep in ctx.attr.deps])
     compiler_classpath = depset(
@@ -46,7 +45,6 @@ def scaladoc_implementation(ctx):
     args.add_all(scalacopts, format_each = "--option=%s")
     args.add_all("--output_html", [html], expand_directories = False)
     args.add_all("--source_jars", src_jars)
-    args.add_all("--tmp", [tmp], expand_directories = False)
     args.add_all("--", srcs)
     args.set_param_file_format("multiline")
     args.use_param_file("@%s", use_always = True)
@@ -67,7 +65,7 @@ def scaladoc_implementation(ctx):
         ),
         mnemonic = "ScalaDoc",
         progress_message = "Generating Scaladoc %{label}",
-        outputs = [html, tmp],
+        outputs = [html],
         toolchain = None,
     )
 

--- a/src/main/scala/higherkindness/rules_scala/workers/common/CommonArguments.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/common/CommonArguments.scala
@@ -37,7 +37,6 @@ class CommonArguments private (
   val sourceJars: List[Path],
   val testFrameworks: List[String],
   val testsFile: Option[Path],
-  val tmpDir: Path,
   val sources: List[Path],
 )
 
@@ -175,12 +174,6 @@ object CommonArguments {
       .`type`(PathArgumentType.apply())
       .setDefault_(Collections.emptyList)
     parser
-      .addArgument("--tmp")
-      .help("Temporary directory")
-      .metavar("path")
-      .required(true)
-      .`type`(PathArgumentType.apply())
-    parser
       .addArgument("sources")
       .help("Source files")
       .metavar("source")
@@ -216,7 +209,6 @@ object CommonArguments {
       sourceJars = SandboxUtil.getSandboxPaths(workDir, namespace.getList[Path]("source_jars")),
       testFrameworks = namespace.getList[String]("test_frameworks").asScala.toList,
       testsFile = Option(namespace.get[Path]("tests_file")).map(SandboxUtil.getSandboxPath(workDir, _)),
-      tmpDir = SandboxUtil.getSandboxPath(workDir, namespace.get[Path]("tmp")),
       sources = SandboxUtil.getSandboxPaths(workDir, namespace.getList[Path]("sources")),
     )
   }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/compile/ZincRunner.scala
@@ -270,7 +270,7 @@ object ZincRunner extends WorkerMain[Unit] {
 
     val logger = new AnnexLogger(workRequest.logLevel, task.workDir, task.output)
 
-    val tmpDir = workRequest.tmpDir
+    val tmpDir = Files.createTempDirectory(task.workDir, "tmp")
 
     // extract srcjars
     val sources = {
@@ -395,7 +395,6 @@ object ZincRunner extends WorkerMain[Unit] {
 
     // clear temporary files
     FileUtil.delete(tmpDir)
-    Files.createDirectory(tmpDir)
 
     InterruptUtil.throwIfInterrupted(task.isCancelled)
   }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/doc/DocRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/doc/DocRunner.scala
@@ -28,7 +28,6 @@ object DocRunner extends WorkerMain[Unit] {
     val options: List[String],
     val outputDir: Path,
     val sources: List[Path],
-    val tmpDir: Path,
   )
 
   private object DocRequest {
@@ -41,7 +40,6 @@ object DocRunner extends WorkerMain[Unit] {
         options = Option(namespace.getList[String]("option")).map(_.asScala.toList).getOrElse(List.empty),
         outputDir = SandboxUtil.getSandboxPath(workDir, namespace.get[Path]("output_html")),
         sources = SandboxUtil.getSandboxPaths(workDir, namespace.getList[Path]("sources")),
-        tmpDir = SandboxUtil.getSandboxPath(workDir, namespace.get[Path]("tmp")),
         sourceJars = SandboxUtil.getSandboxPaths(workDir, namespace.getList[Path]("source_jars")),
       )
     }
@@ -89,12 +87,6 @@ object DocRunner extends WorkerMain[Unit] {
       .`type`(PathArgumentType.apply())
       .setDefault_(Collections.emptyList)
     parser
-      .addArgument("--tmp")
-      .help("Temporary directory")
-      .metavar("path")
-      .required(true)
-      .`type`(PathArgumentType.apply())
-    parser
       .addArgument("--output_html")
       .help("Output directory")
       .metavar("path")
@@ -119,12 +111,7 @@ object DocRunner extends WorkerMain[Unit] {
     )
     InterruptUtil.throwIfInterrupted(task.isCancelled)
 
-    val tmpDir = workRequest.tmpDir
-    try {
-      FileUtil.delete(tmpDir)
-    } catch {
-      case _: NoSuchFileException => {}
-    }
+    val tmpDir = Files.createTempDirectory(task.workDir, "tmp")
 
     val sources = workRequest.sources ++
       workRequest.sourceJars.zipWithIndex
@@ -166,7 +153,6 @@ object DocRunner extends WorkerMain[Unit] {
     } catch {
       case _: NoSuchFileException => {}
     }
-    Files.createDirectory(tmpDir)
     InterruptUtil.throwIfInterrupted(task.isCancelled)
   }
 }


### PR DESCRIPTION
Previously, the Scala rules declared temporary directories via `ctx.actions.declare_directory` and outputted these directories. My guess is that we did this either to get Bazel not to complain about them being unused or for debugging purposes.

This is unnecessary (and actually slower in the context of remote execution), so this commit updates the simple rules to use `mktemp -d` and the persistent worker-backed rules to use the sandbox directory as a temporary directory.