### PR TITLE
Execute test classes concurrently

### DIFF
--- a/.bazelrc_shared
+++ b/.bazelrc_shared
@@ -6,7 +6,7 @@ build --tool_java_language_version="21"
 build --tool_java_runtime_version="remotejdk_21"
 
 # Other options
-build --experimental_use_hermetic_linux_sandbox
+# build --experimental_use_hermetic_linux_sandbox
 build --experimental_worker_cancellation
 build --experimental_worker_multiplex_sandboxing
 build --experimental_worker_sandbox_hardening

--- a/rules/private/phases/phase_test_launcher.bzl
+++ b/rules/private/phases/phase_test_launcher.bzl
@@ -61,6 +61,8 @@ def phase_test_launcher(ctx, g):
         files.append(subprocess_executable)
         args.add("--isolation", "process")
         args.add("--subprocess_exec", subprocess_executable.short_path)
+    if ctx.attr.sequential:
+        args.add("--sequential")
     args.add_all("--", test_jars, map_each = _short_path)
     args.set_param_file_format("multiline")
     args_file = ctx.actions.declare_file("{}/test.params".format(ctx.label.name))

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -382,6 +382,10 @@ def make_scala_test(*extras):
                     cfg = _scala_outgoing_transition,
                     default = "@rules_scala_annex//src/main/scala/higherkindness/rules_scala/workers/zinc/test",
                 ),
+                "sequential": attr.bool(
+                    default = False,
+                    doc = "Whether to run test classes sequentially. If false, they'll be run concurrently.",
+                ),
                 "subprocess_runner": attr.label(
                     cfg = _scala_outgoing_transition,
                     default = "@rules_scala_annex//src/main/scala/higherkindness/rules_scala/common/sbt-testing:subprocess",

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/BufferedLogger.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/BufferedLogger.scala
@@ -1,0 +1,37 @@
+package higherkindness.rules_scala.common.sbt_testing
+
+import sbt.testing.Logger
+
+import scala.collection.mutable
+
+private sealed trait SbtLogEntry
+private object SbtLogEntry {
+  case class Error(message: String) extends SbtLogEntry
+  case class Warn(message: String) extends SbtLogEntry
+  case class Info(message: String) extends SbtLogEntry
+  case class Debug(message: String) extends SbtLogEntry
+  case class Trace(throwable: Throwable) extends SbtLogEntry
+}
+
+class BufferedLogger(underlying: Logger) extends Logger {
+  private val buffer = mutable.ArrayBuffer.empty[SbtLogEntry]
+
+  override def ansiCodesSupported(): Boolean = underlying.ansiCodesSupported()
+  override def error(message: String): Unit = buffer.addOne(SbtLogEntry.Error(message))
+  override def warn(message: String): Unit = buffer.addOne(SbtLogEntry.Warn(message))
+  override def info(message: String): Unit = buffer.addOne(SbtLogEntry.Info(message))
+  override def debug(message: String): Unit = buffer.addOne(SbtLogEntry.Debug(message))
+  override def trace(throwable: Throwable): Unit = buffer.addOne(SbtLogEntry.Trace(throwable))
+
+  def flush(): Unit = {
+    buffer.foreach {
+      case SbtLogEntry.Error(message)   => underlying.error(message)
+      case SbtLogEntry.Warn(message)    => underlying.warn(message)
+      case SbtLogEntry.Info(message)    => underlying.info(message)
+      case SbtLogEntry.Debug(message)   => underlying.debug(message)
+      case SbtLogEntry.Trace(throwable) => underlying.trace(throwable)
+    }
+
+    buffer.clear()
+  }
+}

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/JUnitXmlReporter.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/JUnitXmlReporter.scala
@@ -2,11 +2,10 @@ package higherkindness.rules_scala.common.sbt_testing
 
 import java.io.{PrintWriter, StringWriter}
 import sbt.testing.Status.{Canceled, Error, Failure, Ignored, Pending, Skipped}
-import sbt.testing.{Event, Status, TestSelector}
-import scala.collection.mutable.ListBuffer
+import sbt.testing.{Event, Status, Task, TestSelector}
 import scala.xml.{Elem, Utility, XML}
 
-class JUnitXmlReporter(tasksAndEvents: ListBuffer[(String, ListBuffer[Event])]) {
+class JUnitXmlReporter(taskEvents: Map[Task, Array[Event]]) {
   private def escape(info: String): String = info match {
     case str: String => Utility.escape(str)
     case null        => ""
@@ -14,58 +13,60 @@ class JUnitXmlReporter(tasksAndEvents: ListBuffer[(String, ListBuffer[Event])]) 
 
   def result: Elem =
     XML.loadString(s"""<testsuites>
-      ${(for ((name, events) <- tasksAndEvents)
-        yield s"""<testsuite
+      ${(for {
+        (task, events) <- taskEvents
+        name = task.taskDef.fullyQualifiedName
+      } yield s"""<testsuite
         hostname=""
         name="${escape(name)}"
         tests="${events.size.toString}"
         errors="${events.count(_.status == Error).toString}"
         failures="${events.count(_.status == Failure).toString}"
         skipped="${events
-            .count(e => e.status == Ignored || e.status == Skipped || e.status == Pending || e.status == Canceled)
-            .toString}"
+          .count(e => e.status == Ignored || e.status == Skipped || e.status == Pending || e.status == Canceled)
+          .toString}"
         time="${(events.map(_.duration).sum / 1000d).toString}">
           ${(for (e <- events)
-            yield s"""<testcase
+          yield s"""<testcase
             classname="${escape(name)}"
             name="${e.selector match {
-                case selector: TestSelector => escape(selector.testName)
-                case _                      => "Error occurred outside of a test case."
-              }}"
+              case selector: TestSelector => escape(selector.testName)
+              case _                      => "Error occurred outside of a test case."
+            }}"
             time="${(e.duration / 1000d).toString}">
             ${val stringWriter = new StringWriter()
-              if (e.throwable.isDefined) {
-                val writer = new PrintWriter(stringWriter)
-                e.throwable.get.printStackTrace(writer)
-                writer.flush()
-              }
-              val trace: String = stringWriter.toString
-              e.status match {
-                case Status.Error if e.throwable.isDefined =>
-                  val t = e.throwable.get
-                  s"""<error message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
-                      trace,
-                    )}</error>"""
-                case Status.Error =>
-                  s"""<error message="No Exception or message provided"/>"""
-                case Status.Failure if e.throwable.isDefined =>
-                  val t = e.throwable.get
-                  s"""<failure message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
-                      trace,
-                    )}</failure>"""
-                case Status.Failure =>
-                  s"""<failure message="No Exception or message provided"/>"""
-                case Status.Canceled if e.throwable.isDefined =>
-                  val t = e.throwable.get
-                  s"""<skipped message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
-                      trace,
-                    )}</skipped>"""
-                case Status.Canceled =>
-                  s"""<skipped message="No Exception or message provided"/>"""
-                case Status.Ignored | Status.Skipped | Status.Pending =>
-                  "<skipped/>"
-                case _ =>
-              }}
+            if (e.throwable.isDefined) {
+              val writer = new PrintWriter(stringWriter)
+              e.throwable.get.printStackTrace(writer)
+              writer.flush()
+            }
+            val trace: String = stringWriter.toString
+            e.status match {
+              case Status.Error if e.throwable.isDefined =>
+                val t = e.throwable.get
+                s"""<error message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
+                    trace,
+                  )}</error>"""
+              case Status.Error =>
+                s"""<error message="No Exception or message provided"/>"""
+              case Status.Failure if e.throwable.isDefined =>
+                val t = e.throwable.get
+                s"""<failure message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
+                    trace,
+                  )}</failure>"""
+              case Status.Failure =>
+                s"""<failure message="No Exception or message provided"/>"""
+              case Status.Canceled if e.throwable.isDefined =>
+                val t = e.throwable.get
+                s"""<skipped message="${escape(t.getMessage)}" type="${escape(t.getClass.getName)}">${escape(
+                    trace,
+                  )}</skipped>"""
+              case Status.Canceled =>
+                s"""<skipped message="No Exception or message provided"/>"""
+              case Status.Ignored | Status.Skipped | Status.Pending =>
+                "<skipped/>"
+              case _ =>
+            }}
           </testcase>""").mkString("")}
         <system-out><![CDATA[]]></system-out>
         <system-err><![CDATA[]]></system-err>

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/SubprocessRunner.scala
@@ -3,7 +3,8 @@ package higherkindness.rules_scala.common.sbt_testing
 import higherkindness.rules_scala.common.classloaders.ClassLoaders
 import java.io.ObjectInputStream
 import java.nio.file.Paths
-import scala.collection.mutable
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 object SubprocessTestRunner {
 
@@ -20,14 +21,16 @@ object SubprocessTestRunner {
         val tasks = runner.tasks(Array(TestHelper.taskDef(request.test, request.scopeAndTestName)))
         tasks.length == 0 || {
           val reporter = new TestReporter(request.logger)
-          val taskExecutor = new TestTaskExecutor(request.logger)
-          val failures = mutable.Set[String]()
-          tasks.foreach { task =>
-            reporter.preTask(task)
-            taskExecutor.execute(task, failures)
-            reporter.postTask()
-          }
-          !failures.nonEmpty
+
+          // We're only running a single test class, so there's not much of a point in using the
+          // `ConcurrentTestTaskExecutor`
+          val taskExecutor = new SequentialTestTaskExecutor(request.logger)
+
+          tasks.foreach(taskExecutor.submitTask)
+
+          val result = Await.result(taskExecutor.waitForTasks(), Duration.Inf)
+
+          !result.failures.nonEmpty
         }
       }
     }

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
@@ -37,7 +37,7 @@ class TestFrameworkLoader(loader: ClassLoader) {
         (Some(`class`.getDeclaredConstructor().newInstance()), loadedJar)
       } catch {
         case _: ClassNotFoundException => (None, None)
-        case NonFatal(e) => throw new Exception(s"Failed to load framework $className", e)
+        case NonFatal(e)               => throw new Exception(s"Failed to load framework $className", e)
       }
     framework.map {
       case framework: Framework =>

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/Test.scala
@@ -2,7 +2,7 @@ package higherkindness.rules_scala.common.sbt_testing
 
 import java.nio.file.{Path, Paths}
 import play.api.libs.json.{Format, Json}
-import sbt.testing.{Event, Framework, Logger, Runner, Status, Task, TaskDef, TestWildcardSelector}
+import sbt.testing.{Framework, Logger, Runner, Task, TaskDef, TestWildcardSelector}
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
@@ -37,7 +37,7 @@ class TestFrameworkLoader(loader: ClassLoader) {
         (Some(`class`.getDeclaredConstructor().newInstance()), loadedJar)
       } catch {
         case _: ClassNotFoundException => (None, None)
-        case NonFatal(e)               => throw new Exception(s"Failed to load framework $className", e)
+        case NonFatal(e) => throw new Exception(s"Failed to load framework $className", e)
       }
     framework.map {
       case framework: Framework =>
@@ -100,26 +100,4 @@ class TestReporter(logger: Logger) {
   }
 
   def preTask(task: Task) = logger.info(task.taskDef.fullyQualifiedName)
-}
-
-class TestTaskExecutor(logger: Logger) {
-  def execute(task: Task, failures: mutable.Set[String]): mutable.ListBuffer[Event] = {
-    var events = new mutable.ListBuffer[Event]()
-    def execute(task: Task): Unit = {
-      val tasks = task.execute(
-        event => {
-          events += event
-          event.status match {
-            case Status.Failure | Status.Error =>
-              failures += task.taskDef.fullyQualifiedName
-            case _ =>
-          }
-        },
-        Array(new PrefixedTestingLogger(logger, "    ")),
-      )
-      tasks.foreach(execute)
-    }
-    execute(task)
-    events
-  }
 }

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestTaskExecutor.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestTaskExecutor.scala
@@ -1,0 +1,26 @@
+package higherkindness.rules_scala.common.sbt_testing
+
+import sbt.testing.{Event, Logger, Status, Task}
+import scala.collection.mutable
+
+class TestTaskExecutor(logger: Logger) {
+  def execute(task: Task, failures: mutable.Set[String]): mutable.ListBuffer[Event] = {
+    var events = new mutable.ListBuffer[Event]()
+    def execute(task: Task): Unit = {
+      val tasks = task.execute(
+        event => {
+          events += event
+          event.status match {
+            case Status.Failure | Status.Error =>
+              failures += task.taskDef.fullyQualifiedName
+            case _ =>
+          }
+        },
+        Array(new PrefixedTestingLogger(logger, "    ")),
+      )
+      tasks.foreach(execute)
+    }
+    execute(task)
+    events
+  }
+}

--- a/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestTaskExecutor.scala
+++ b/src/main/scala/higherkindness/rules_scala/common/sbt-testing/TestTaskExecutor.scala
@@ -1,26 +1,119 @@
 package higherkindness.rules_scala.common.sbt_testing
 
+import java.util.concurrent.ConcurrentLinkedQueue
 import sbt.testing.{Event, Logger, Status, Task}
-import scala.collection.mutable
+import scala.collection.{concurrent, mutable}
+import scala.concurrent.{blocking, ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
 
-class TestTaskExecutor(logger: Logger) {
-  def execute(task: Task, failures: mutable.Set[String]): mutable.ListBuffer[Event] = {
-    var events = new mutable.ListBuffer[Event]()
-    def execute(task: Task): Unit = {
-      val tasks = task.execute(
-        event => {
-          events += event
-          event.status match {
-            case Status.Failure | Status.Error =>
-              failures += task.taskDef.fullyQualifiedName
-            case _ =>
-          }
-        },
-        Array(new PrefixedTestingLogger(logger, "    ")),
-      )
-      tasks.foreach(execute)
+case class TaskExecutorResult(taskEvents: Map[Task, Array[Event]], failures: Array[String])
+
+private object TaskExecutorResult {
+  private[sbt_testing] case class Mutable(
+    taskEvents: concurrent.TrieMap[Task, ConcurrentLinkedQueue[Event]],
+    failures: ConcurrentLinkedQueue[String],
+  ) {
+    def clear(): Unit = {
+      taskEvents.clear()
+      failures.clear()
     }
-    execute(task)
-    events
+
+    def toTaskExecutorResult: TaskExecutorResult = TaskExecutorResult(
+      taskEvents.view.map { case task -> events => task -> events.asScala.toArray }.toMap,
+      failures.asScala.toArray,
+    )
+  }
+
+  private[sbt_testing] object Mutable {
+    def empty: Mutable = apply(concurrent.TrieMap.empty, new ConcurrentLinkedQueue())
+  }
+}
+
+trait TestTaskExecutor {
+  def submitTask(task: Task): Unit
+  def waitForTasks(): Future[TaskExecutorResult]
+}
+
+class ConcurrentTestTaskExecutor(logger: Logger) extends TestTaskExecutor {
+  private val activeTasks = new ConcurrentLinkedQueue[Future[Unit]]()
+  private val currentResult = TaskExecutorResult.Mutable.empty
+
+  override def submitTask(task: Task): Unit = activeTasks.add(
+    Future {
+      blocking {
+        val bufferedLogger = new BufferedLogger(logger)
+        val reporter = new TestReporter(bufferedLogger)
+
+        reporter.preTask(task)
+
+        val additionalTasks = task.execute(
+          event => {
+            currentResult.synchronized {
+              currentResult.taskEvents.getOrElseUpdate(task, new ConcurrentLinkedQueue()).add(event)
+
+              event.status match {
+                case Status.Failure | Status.Error => currentResult.failures.add(task.taskDef.fullyQualifiedName)
+                case _                             =>
+              }
+            }
+          },
+          Array(new PrefixedTestingLogger(bufferedLogger, "    ")),
+        )
+
+        additionalTasks.foreach(submitTask)
+
+        reporter.postTask()
+
+        // Only one task should write to stderr/stdout at a time. Of course, the task implementation could write to
+        // stdout/stderr directly, but that's out of our control.
+        synchronized {
+          bufferedLogger.flush()
+        }
+      }
+    }(ExecutionContext.global),
+  )
+
+  override def waitForTasks(): Future[TaskExecutorResult] = {
+    given ExecutionContext = ExecutionContext.global
+
+    Future
+      .sequence(activeTasks.asScala)
+      .map { _ =>
+        activeTasks.clear()
+        currentResult.toTaskExecutorResult
+      }(ExecutionContext.global)
+  }
+}
+
+class SequentialTestTaskExecutor(logger: Logger) extends TestTaskExecutor {
+  private val currentResult = TaskExecutorResult.Mutable.empty
+
+  override def submitTask(task: Task): Unit = {
+    val reporter = new TestReporter(logger)
+
+    reporter.preTask(task)
+
+    val additionalTasks = task.execute(
+      event => {
+        currentResult.taskEvents.getOrElseUpdate(task, new ConcurrentLinkedQueue()).add(event)
+
+        event.status match {
+          case Status.Failure | Status.Error => currentResult.failures.add(task.taskDef.fullyQualifiedName)
+          case _                             =>
+        }
+      },
+      Array(new PrefixedTestingLogger(logger, "    ")),
+    )
+
+    additionalTasks.foreach(submitTask)
+    reporter.postTask()
+  }
+
+  override def waitForTasks(): Future[TaskExecutorResult] = {
+    val result = currentResult.toTaskExecutorResult
+
+    currentResult.clear()
+
+    Future.successful(result)
   }
 }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
@@ -10,38 +10,48 @@ import higherkindness.rules_scala.common.sbt_testing.TestRequest
 import higherkindness.rules_scala.common.sbt_testing.TestTaskExecutor
 import java.io.ObjectOutputStream
 import java.nio.file.Path
-import sbt.testing.{Event, Framework, Logger}
+import sbt.testing.{Framework, Logger}
 import scala.collection.mutable
+import scala.concurrent.{blocking, ExecutionContext, Future}
 
-class BasicTestRunner(framework: Framework, classLoader: ClassLoader, logger: Logger) extends TestFrameworkRunner {
-  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]) = {
-    var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
+class BasicTestRunner(
+  framework: Framework,
+  classLoader: ClassLoader,
+  logger: Logger,
+  testTaskExecutor: TestTaskExecutor,
+) extends TestFrameworkRunner {
+  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]): Future[Boolean] = {
     ClassLoaders.withContextClassLoader(classLoader) {
       TestHelper.withRunner(framework, scopeAndTestName, classLoader, arguments) { runner =>
         val reporter = new TestReporter(logger)
         val tasks = runner.tasks(tests.map(TestHelper.taskDef(_, scopeAndTestName)).toArray)
         reporter.pre(framework, tasks)
-        val taskExecutor = new TestTaskExecutor(logger)
-        val failures = mutable.Set[String]()
-        tasks.foreach { task =>
-          reporter.preTask(task)
-          val events = taskExecutor.execute(task, failures)
-          reporter.postTask()
-          tasksAndEvents += ((task.taskDef.fullyQualifiedName, events))
-        }
-        reporter.post(failures)
-        val xmlReporter = new JUnitXmlReporter(tasksAndEvents)
-        xmlReporter.write()
-        !failures.nonEmpty
+        tasks.foreach(testTaskExecutor.submitTask)
+        testTaskExecutor
+          .waitForTasks()
+          .map { result =>
+            blocking {
+              reporter.post(result.failures)
+
+              val xmlReporter = new JUnitXmlReporter(result.taskEvents)
+
+              xmlReporter.write()
+
+              !result.failures.nonEmpty
+            }
+          }(ExecutionContext.global)
       }
     }
   }
 }
 
-class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => ClassLoader, logger: Logger)
-    extends TestFrameworkRunner {
-  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]) = {
-    var tasksAndEvents = new mutable.ListBuffer[(String, mutable.ListBuffer[Event])]()
+class ClassLoaderTestRunner(
+  framework: Framework,
+  classLoaderProvider: () => ClassLoader,
+  logger: Logger,
+  testTaskExecutor: TestTaskExecutor,
+) extends TestFrameworkRunner {
+  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]): Future[Boolean] = {
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
@@ -52,27 +62,30 @@ class ClassLoaderTestRunner(framework: Framework, classLoaderProvider: () => Cla
       }
     }
 
-    val taskExecutor = new TestTaskExecutor(logger)
-    val failures = mutable.Set[String]()
     tests.foreach { test =>
       val classLoader = classLoaderProvider()
       val isolatedFramework = new TestFrameworkLoader(classLoader).load(framework.getClass.getName).get
       TestHelper.withRunner(isolatedFramework, scopeAndTestName, classLoader, arguments) { runner =>
         ClassLoaders.withContextClassLoader(classLoader) {
           val tasks = runner.tasks(Array(TestHelper.taskDef(test, scopeAndTestName)))
-          tasks.foreach { task =>
-            reporter.preTask(task)
-            val events = taskExecutor.execute(task, failures)
-            reporter.postTask()
-            tasksAndEvents += ((task.taskDef.fullyQualifiedName, events))
-          }
+          tasks.foreach(testTaskExecutor.submitTask)
         }
       }
     }
-    reporter.post(failures)
-    val xmlReporter = new JUnitXmlReporter(tasksAndEvents)
-    xmlReporter.write()
-    !failures.nonEmpty
+
+    testTaskExecutor
+      .waitForTasks()
+      .map { result =>
+        blocking {
+          reporter.post(result.failures)
+
+          val xmlReporter = new JUnitXmlReporter(result.taskEvents)
+
+          xmlReporter.write()
+
+          !result.failures.nonEmpty
+        }
+      }(ExecutionContext.global)
   }
 }
 
@@ -87,7 +100,7 @@ class ProcessTestRunner(
   command: ProcessCommand,
   logger: Logger with Serializable,
 ) extends TestFrameworkRunner {
-  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]) = {
+  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]): Future[Boolean] = {
     val reporter = new TestReporter(logger)
 
     val classLoader = framework.getClass.getClassLoader
@@ -122,10 +135,10 @@ class ProcessTestRunner(
       } finally process.destroy
     }
     reporter.post(failures)
-    !failures.nonEmpty
+    Future.successful(!failures.nonEmpty) // We don't yet support concurrent execution with process isolation
   }
 }
 
 trait TestFrameworkRunner {
-  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]): Boolean
+  def execute(tests: List[TestDefinition], scopeAndTestName: String, arguments: List[String]): Future[Boolean]
 }

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestFrameworkRunner.scala
@@ -98,7 +98,6 @@ class ProcessTestRunner(
       }
     }
 
-    val taskExecutor = new TestTaskExecutor(logger)
     val failures = mutable.Set[String]()
     tests.foreach { test =>
       val process = new ProcessBuilder((command.executable +: command.arguments): _*)

--- a/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
+++ b/src/main/scala/higherkindness/rules_scala/workers/zinc/test/TestRunner.scala
@@ -4,7 +4,8 @@ import higherkindness.rules_scala.common.args.ArgsUtil.PathArgumentType
 import higherkindness.rules_scala.common.args.implicits.*
 import higherkindness.rules_scala.common.classloaders.ClassLoaders
 import higherkindness.rules_scala.common.sandbox.SandboxUtil
-import higherkindness.rules_scala.common.sbt_testing.{AnnexTestingLogger, TestDefinition, TestFrameworkLoader, TestsFileData, Verbosity}
+import higherkindness.rules_scala.common.sbt_testing.{AnnexTestingLogger, ConcurrentTestTaskExecutor, SequentialTestTaskExecutor, TestDefinition, TestFrameworkLoader, TestsFileData, Verbosity}
+import higherkindness.rules_scala.workers.zinc.test.TestRunner.Isolation
 import java.io.FileInputStream
 import java.net.URLClassLoader
 import java.nio.file.attribute.FileTime
@@ -16,6 +17,8 @@ import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments
 import net.sourceforge.argparse4j.inf.{ArgumentParser, Namespace}
 import play.api.libs.json.Json
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
@@ -83,9 +86,10 @@ object TestRunner {
   }
 
   private class TestRunnerRequest private (
-    val subprocessExecutable: Option[Path],
     val isolation: Isolation,
+    val sequential: Boolean,
     val sharedClasspath: List[Path],
+    val subprocessExecutable: Option[Path],
     val testClasspath: List[Path],
     val testsFile: Path,
   )
@@ -93,10 +97,11 @@ object TestRunner {
   private object TestRunnerRequest {
     def apply(runPath: Path, namespace: Namespace): TestRunnerRequest = {
       new TestRunnerRequest(
+        isolation = Isolation(namespace.getString("isolation")),
+        sequential = namespace.getBoolean("sequential"),
+        sharedClasspath = SandboxUtil.getSandboxPaths(runPath, namespace.getList[Path]("shared_classpath")),
         subprocessExecutable =
           Option(namespace.get[Path]("subprocess_exec")).map(SandboxUtil.getSandboxPath(runPath, _)),
-        isolation = Isolation(namespace.getString("isolation")),
-        sharedClasspath = SandboxUtil.getSandboxPaths(runPath, namespace.getList[Path]("shared_classpath")),
         testClasspath = SandboxUtil.getSandboxPaths(runPath, namespace.getList[Path]("classpath")),
         testsFile = namespace.get[Path]("tests_file"),
       )
@@ -106,14 +111,14 @@ object TestRunner {
   private val testArgParser: ArgumentParser = {
     val parser = ArgumentParsers.newFor("test").addHelp(true).build()
     parser
-      .addArgument("--subprocess_exec")
-      .help("Executable for SubprocessTestRunner")
-      .`type`(PathArgumentType.apply())
-    parser
       .addArgument("--isolation")
       .choices(Isolation.values.keys.toSeq: _*)
       .help("Test isolation")
       .setDefault_(Isolation.None.level)
+    parser
+      .addArgument("--sequential")
+      .help("If passed, run test classes sequentially instead of concurrently.")
+      .action(Arguments.storeTrue())
     parser
       .addArgument("--shared_classpath")
       .help("Classpath to share between tests")
@@ -121,6 +126,10 @@ object TestRunner {
       .nargs("*")
       .`type`(PathArgumentType.apply())
       .setDefault_(Collections.emptyList)
+    parser
+      .addArgument("--subprocess_exec")
+      .help("Executable for SubprocessTestRunner")
+      .`type`(PathArgumentType.apply())
     parser
       .addArgument("--tests_file")
       .help("File containing discovered tests.")
@@ -188,11 +197,21 @@ object TestRunner {
           }
         }
         filteredTests.isEmpty || {
+          if (testRunnerRequest.sequential && testRunnerRequest.isolation == Isolation.Process) {
+            throw new Exception("Process isolation isn't yet compatible with sequential execution.")
+          }
+
+          val testTaskExecutor = if (testRunnerRequest.sequential) {
+            new SequentialTestTaskExecutor(logger)
+          } else {
+            new ConcurrentTestTaskExecutor(logger)
+          }
+
           val runner = testRunnerRequest.isolation match {
             case Isolation.ClassLoader =>
               val urls = testClasspath.filterNot(sharedClasspath.toSet).map(_.toUri.toURL).toArray
               def classLoaderProvider() = new URLClassLoader(urls, sharedClassLoader)
-              new ClassLoaderTestRunner(framework, classLoaderProvider _, logger)
+              new ClassLoaderTestRunner(framework, classLoaderProvider _, logger, testTaskExecutor)
             case Isolation.Process =>
               val executable = testRunnerRequest.subprocessExecutable.map(_.toString).getOrElse {
                 throw new Exception("Subprocess executable missing for test ran in process isolation mode.")
@@ -203,11 +222,14 @@ object TestRunner {
                 new ProcessCommand(executable, testRunnerArgs.subprocessArgs),
                 logger,
               )
-            case Isolation.None => new BasicTestRunner(framework, classLoader, logger)
+            case Isolation.None => new BasicTestRunner(framework, classLoader, logger, testTaskExecutor)
           }
 
           try {
-            runner.execute(filteredTests.toList, testScopeAndName.getOrElse(""), testRunnerArgs.frameworkArgs)
+            Await.result(
+              runner.execute(filteredTests.toList, testScopeAndName.getOrElse(""), testRunnerArgs.frameworkArgs),
+              Duration.Inf,
+            )
           } catch {
             case e: Throwable =>
               e.printStackTrace()

--- a/tests/test-frameworks/concurrency/BUILD.bazel
+++ b/tests/test-frameworks/concurrency/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_scala_annex//rules:scala.bzl", "scala_test")
+
+scala_test(
+    name = "concurrent",
+    srcs = glob(["*.scala"]),
+    jvm_flags = ["-DTEST_MODE=concurrent"],
+    deps = ["@annex_test//:org_specs2_specs2_core_2_13"],
+)
+
+scala_test(
+    name = "sequential",
+    srcs = glob(["*.scala"]),
+    jvm_flags = ["-DTEST_MODE=sequential"],
+    sequential = True,
+    deps = ["@annex_test//:org_specs2_specs2_core_2_13"],
+)

--- a/tests/test-frameworks/concurrency/Spec1.scala
+++ b/tests/test-frameworks/concurrency/Spec1.scala
@@ -1,0 +1,9 @@
+package annex.concurrency
+
+import org.specs2.mutable.Specification
+
+class Spec1 extends Specification {
+  println("Spec1 executing...")
+
+  maybeWaitForOthers()
+}

--- a/tests/test-frameworks/concurrency/Spec2.scala
+++ b/tests/test-frameworks/concurrency/Spec2.scala
@@ -1,0 +1,9 @@
+package annex.concurrency
+
+import org.specs2.mutable.Specification
+
+class Spec2 extends Specification {
+  println("Spec2 executing...")
+
+  maybeWaitForOthers()
+}

--- a/tests/test-frameworks/concurrency/Spec3.scala
+++ b/tests/test-frameworks/concurrency/Spec3.scala
@@ -1,0 +1,9 @@
+package annex.concurrency
+
+import org.specs2.mutable.Specification
+
+class Spec3 extends Specification {
+  println("Spec3 executing...")
+
+  maybeWaitForOthers()
+}

--- a/tests/test-frameworks/concurrency/Spec4.scala
+++ b/tests/test-frameworks/concurrency/Spec4.scala
@@ -1,0 +1,9 @@
+package annex.concurrency
+
+import org.specs2.mutable.Specification
+
+class Spec4 extends Specification {
+  println("Spec4 executing...")
+
+  maybeWaitForOthers()
+}

--- a/tests/test-frameworks/concurrency/package.scala
+++ b/tests/test-frameworks/concurrency/package.scala
@@ -1,0 +1,21 @@
+package annex
+
+import java.util.concurrent.CountDownLatch
+
+package object concurrency {
+  private val testLatch = new CountDownLatch(4)
+
+  /**
+   * All of the tests call this method to wait for each other to have started and printed a message before exiting.
+   *
+   * This allows us to verify with certainty that the tests' output is buffered, because if it weren't, each would
+   * print its "pre" message (the test name), followed by a "SpecX executing..." message, followed by its
+   * "post" message. The *only* way to get all the "pre" message printed first and in sequence is if the output is
+   * buffered and the "pre" and "post" messages are flushed at the end of the test, after all the
+   * "SpecX executing..." messages have been printed.
+   */
+  def maybeWaitForOthers(): Unit = if (Option(System.getProperty("TEST_MODE")).contains[String]("concurrent")) {
+    System.out.flush()
+    testLatch.countDown()
+  }
+}

--- a/tests/test-frameworks/concurrency/test
+++ b/tests/test-frameworks/concurrency/test
@@ -1,0 +1,74 @@
+#!/bin/bash -e
+. "$(dirname "$0")"/../../common.sh
+
+# That the test completes at all is proof that the test classes are executed concurrently, because each waits for all
+# the others to start. This means that if the test doesn't complete, then the test classes are being executed
+# sequentially. You may find this helpful for debugging.
+concurrent_output="$(bazel run :concurrent)"
+
+# The logs for each test class should be buffered. See `tests/test-frameworks/concurrency/package.scala` to understand
+# why these messages being printed in sequence is proof of that.
+echo "$concurrent_output" | grep 'Spec\d executing...
+Spec\d executing...
+Spec\d executing...
+Spec\d executing...
+'
+
+# The output for each test class shouldn't be interleaved
+for i in {1..4}; do
+  echo "$concurrent_output" | grep "com.lucidchart.example.Spec$i
+    Spec$i
+
+
+
+    Total for specification Spec$i
+"
+done
+
+sequential_output="$(bazel run :sequential)"
+
+# The test classes should run in order
+echo "$sequential_output" | grep '
+com\.lucidchart\.example\.Spec1
+Spec1 executing\.\.\.
+    Spec1
+
+
+
+    Total for specification Spec1
+    Finished in .*
+0 example, 0 failure, 0 error
+
+
+com\.lucidchart\.example\.Spec2
+Spec2 executing\.\.\.
+    Spec2
+
+
+
+    Total for specification Spec2
+    Finished in .*
+0 example, 0 failure, 0 error
+
+
+com\.lucidchart\.example\.Spec3
+Spec3 executing\.\.\.
+    Spec3
+
+
+
+    Total for specification Spec3
+    Finished in .*
+0 example, 0 failure, 0 error
+
+
+com\.lucidchart\.example\.Spec4
+Spec4 executing\.\.\.
+    Spec4
+
+
+
+    Total for specification Spec4
+    Finished in .*
+0 example, 0 failure, 0 error
+'


### PR DESCRIPTION
This PR updates the test runner to execute test classes (formally referred to as _tasks_ in the context of the SBT test interface) concurrently. Most test frameworks will already execute individual test cases concurrently, but it's up to the test runner to execute whole test classes at the same time.

SBT [already does this by default](https://github.com/etorreborre/specs2/issues/60), so I think it's reasonable to expect that Bazel should do this via `rules_scala`. However, if this isn't desired because a test depends on sequential execution (e.g. because it relies on some global state), one can set `sequential = True` on the `scala_test` target to disable this feature.

One consequence of this change is that we don't print a summary for each test class until after it's finished executing, but I figured this shouldn't be too big of an issue as Bazel buffers test output by default anyway.